### PR TITLE
Add batch launcher and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ A Python tool that analyzes the Warframe Market API to find profitable item sets
 ### Option 1: Simple Download (Windows)
 
 1. [Download the latest release](https://github.com/Engusseus/Warframe-Market-Set-Profit-Analyzer/releases/tag/v0.1.0) 
-2. Extract the ZIP file to any folder
-3. Double-click `run-analyzer.bat`
+2. Extract the ZIP file (or clone this repository) to any folder
+3. Double-click `run-analyzer.bat` in the project root
 4. The script will automatically:
    - Check if Python is installed (and prompt you to install it if needed)
    - Set up a virtual environment
@@ -33,8 +33,8 @@ A Python tool that analyzes the Warframe Market API to find profitable item sets
 
 1. Clone this repository:
    ```
-   git clone https://github.com/yourusername/warframe-market-analyzer.git
-   cd warframe-market-analyzer
+   git clone https://github.com/yourusername/Warframe-Market-Set-Profit-Analyzer.git
+   cd Warframe-Market-Set-Profit-Analyzer
    ```
 
 2. Create a virtual environment (recommended):

--- a/run-analyzer.bat
+++ b/run-analyzer.bat
@@ -1,0 +1,29 @@
+@echo off
+REM Warframe Market Set Profit Analyzer Launcher
+
+REM Check if Python is installed
+python --version >nul 2>&1
+if %ERRORLEVEL% neq 0 (
+    echo Python is not installed. Please install Python 3.7 or higher and try again.
+    pause
+    exit /b 1
+)
+
+set VENV=venv
+
+REM Create virtual environment if it doesn't exist
+if not exist %VENV%\Scripts\python.exe (
+    echo Creating virtual environment...
+    python -m venv %VENV%
+)
+
+REM Activate virtual environment
+call %VENV%\Scripts\activate.bat
+
+REM Install dependencies
+pip install -r requirements.txt
+
+REM Run the analyzer
+python wf_market_analyzer.py
+
+pause


### PR DESCRIPTION
## Summary
- supply missing `run-analyzer.bat` launcher for Windows users
- clarify quick-start instructions for the batch file
- fix manual installation clone URL

## Testing
- `python -m py_compile wf_market_analyzer.py config.py`
- `pip install -r requirements.txt`
- `python wf_market_analyzer.py` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685926c082348328b6541b22a19dfe71