### PR TITLE
Add configurable output format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,5 @@ env/
 # Project-specific
 *.log
 set_profit_analysis.csv
+set_profit_analysis.xlsx
 set_profit_analysis_detailed.json

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Python tool that analyzes the Warframe Market API to find profitable item sets
 - Calculates potential profit for each set by comparing set prices to individual part prices
 - Tracks 48-hour trading volume for each set
 - Scores items based on a weighted combination of profit and volume
-- Generates a CSV report ordered by score for easy decision-making
+- Generates a CSV or Excel (XLSX) report ordered by score for easy decision-making
 
 ## Requirements
 
@@ -27,7 +27,7 @@ A Python tool that analyzes the Warframe Market API to find profitable item sets
    - Set up a virtual environment
    - Install all required packages
    - Run the analyzer
-   - Save results to `set_profit_analysis.csv` in the same folder
+   - Save results to `set_profit_analysis.csv` (or `.xlsx` if configured) in the same folder
 
 ### Option 2: Manual Setup (All Platforms)
 
@@ -66,7 +66,7 @@ The script will:
 2. Calculate profit margins for each set
 3. Track 48-hour trading volume
 4. Generate a score based on profit and volume
-5. Save results to `set_profit_analysis.csv`
+5. Save results to `set_profit_analysis.csv` (or `.xlsx` depending on `OUTPUT_FORMAT`)
 
 ## Configuration
 
@@ -75,7 +75,8 @@ Adjust the values in `config.py` to customize how the analyzer behaves:
 - `API_BASE_URL`: Base URL for the Warframe Market API
 - `REQUESTS_PER_SECOND`: Control the request rate
 - `PROFIT_WEIGHT` and `VOLUME_WEIGHT`: Balance profit versus volume in the score
-- `OUTPUT_FILE`: File path for the generated CSV
+- `OUTPUT_FILE`: File path for the generated output file
+- `OUTPUT_FORMAT`: Choose `'csv'` or `'xlsx'` for the output format
 - `DEBUG_MODE`: Enable or disable detailed logging
 - `PRICE_SAMPLE_SIZE`: Number of orders to average when calculating prices
 

--- a/config.py
+++ b/config.py
@@ -14,6 +14,8 @@ HEADERS = {
 
 # Output Settings
 OUTPUT_FILE = 'set_profit_analysis.csv'
+# Choose 'csv' or 'xlsx'
+OUTPUT_FORMAT = 'csv'
 DEBUG_MODE = True  # Enable detailed logging
 
 # Scoring Settings

--- a/sample-output.md
+++ b/sample-output.md
@@ -1,6 +1,7 @@
 # Sample Output
 
-Below is a sample of the CSV output format produced by the Warframe Market Set Profit Analyzer:
+Below is a sample of the CSV output format produced by the Warframe Market Set Profit Analyzer.
+If you choose the `xlsx` format, you'll get the same information in an Excel file:
 
 | Set Name | Profit | Set Selling Price | Part Costs Total | Volume (48h) | Score | Part Prices |
 |----------|--------|-------------------|------------------|--------------|-------|-------------|

--- a/wf_market_analyzer.py
+++ b/wf_market_analyzer.py
@@ -16,6 +16,7 @@ from config import (
     REQUESTS_PER_SECOND,
     HEADERS,
     OUTPUT_FILE,
+    OUTPUT_FORMAT,
     DEBUG_MODE,
     PROFIT_WEIGHT,
     VOLUME_WEIGHT,
@@ -491,9 +492,10 @@ class SetProfitAnalyzer:
         self.results = results
         logger.info(f"Analysis complete. Found {len(results)} profitable sets.")
 
-    def save_to_csv(self):
-        """Save results to CSV file"""
-        logger.info(f"Saving results to {OUTPUT_FILE}")
+    def save_results(self):
+        """Save results to CSV or XLSX file based on configuration"""
+        output_name = OUTPUT_FILE if OUTPUT_FORMAT.lower() == 'csv' else OUTPUT_FILE.replace('.csv', '.xlsx')
+        logger.info(f"Saving results to {output_name}")
 
         # Prepare data for CSV
         csv_data = []
@@ -516,10 +518,13 @@ class SetProfitAnalyzer:
             }
             csv_data.append(row)
 
-        # Create DataFrame and save to CSV
+        # Create DataFrame and save in chosen format
         df = pd.DataFrame(csv_data)
-        df.to_csv(OUTPUT_FILE, index=False)
-        logger.info(f"Results saved to {OUTPUT_FILE}")
+        if OUTPUT_FORMAT.lower() == 'xlsx':
+            df.to_excel(output_name, index=False)
+        else:
+            df.to_csv(output_name, index=False)
+        logger.info(f"Results saved to {output_name}")
 
         # Save detailed JSON for debugging
         if DEBUG_MODE:
@@ -567,7 +572,7 @@ async def main():
     try:
         await analyzer.initialize()
         await analyzer.analyze_all_sets()
-        analyzer.save_to_csv()
+        analyzer.save_results()
     except Exception as e:
         logger.error(f"Error in main execution: {str(e)}", exc_info=True)
     finally:
@@ -576,7 +581,8 @@ async def main():
 
 if __name__ == "__main__":
     print("=== Warframe Market Set Profit Analyzer ===")
-    print(f"Output will be saved to: {OUTPUT_FILE}")
+    output_name = OUTPUT_FILE if OUTPUT_FORMAT.lower() == 'csv' else OUTPUT_FILE.replace('.csv', '.xlsx')
+    print(f"Output will be saved to: {output_name}")
     print("Starting analysis...")
 
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `OUTPUT_FORMAT` config option
- support saving results in CSV or XLSX
- document how to choose output format
- ignore `.xlsx` output

## Testing
- `python -m py_compile config.py wf_market_analyzer.py`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_686d2f6bd7188328b69b5a66a4c0c1d8