### PR TITLE
Add CLI argument overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ Run the analyzer:
 python wf_market_analyzer.py
 ```
 
+You can override settings directly from the command line. For example, to use
+the Xbox market and change the scoring weights:
+
+```
+python wf_market_analyzer.py --platform xbox --output-file xbox_results.csv \
+    --profit-weight 1.0 --volume-weight 1.5
+```
+
 The script will:
 1. Fetch all tradable item sets
 2. Calculate profit margins for each set

--- a/wf_market_analyzer.py
+++ b/wf_market_analyzer.py
@@ -1,6 +1,7 @@
 # Warframe Market Set Profit Analyzer
 # Identifies profitable item sets based on a combined score of profit and trading volume
 
+import argparse
 import asyncio
 import aiohttp
 import pandas as pd
@@ -560,8 +561,33 @@ class SetProfitAnalyzer:
             logger.info(f"Detailed results saved to {json_file}")
 
 
-async def main():
+def parse_arguments() -> argparse.Namespace:
+    """Parse command-line arguments"""
+    parser = argparse.ArgumentParser(description="Warframe Market Set Profit Analyzer")
+    parser.add_argument("--platform", default=HEADERS.get("Platform", "pc"), help="Platform to query (pc, ps4, xbox, switch)")
+    parser.add_argument("--output-file", default=OUTPUT_FILE, help="Path to the output CSV file")
+    parser.add_argument("--profit-weight", type=float, default=PROFIT_WEIGHT, help="Weight for profit in score calculation")
+    parser.add_argument("--volume-weight", type=float, default=VOLUME_WEIGHT, help="Weight for 48h volume in score calculation")
+    parser.add_argument("--price-sample-size", type=int, default=PRICE_SAMPLE_SIZE, help="Number of orders used when averaging prices")
+    parser.add_argument("--debug", action="store_true", default=DEBUG_MODE, help="Enable debug logging")
+    return parser.parse_args()
+
+
+async def main(args: argparse.Namespace) -> None:
     """Main entry point"""
+    global OUTPUT_FILE, PROFIT_WEIGHT, VOLUME_WEIGHT, PRICE_SAMPLE_SIZE, DEBUG_MODE
+
+    # Apply command-line overrides
+    HEADERS["Platform"] = args.platform
+    OUTPUT_FILE = args.output_file
+    PROFIT_WEIGHT = args.profit_weight
+    VOLUME_WEIGHT = args.volume_weight
+    PRICE_SAMPLE_SIZE = args.price_sample_size
+    DEBUG_MODE = args.debug
+
+    if DEBUG_MODE:
+        logger.setLevel(logging.DEBUG)
+
     analyzer = SetProfitAnalyzer()
 
     try:
@@ -576,9 +602,10 @@ async def main():
 
 if __name__ == "__main__":
     print("=== Warframe Market Set Profit Analyzer ===")
-    print(f"Output will be saved to: {OUTPUT_FILE}")
+    args = parse_arguments()
+    print(f"Output will be saved to: {args.output_file}")
     print("Starting analysis...")
 
-    asyncio.run(main())
+    asyncio.run(main(args))
 
     print("Analysis complete!")


### PR DESCRIPTION
## Summary
- allow command line overrides for platform, output file and scoring weights using argparse
- update main() to use parsed arguments
- document example usage of CLI options in README

## Testing
- `python -m py_compile wf_market_analyzer.py`
- `python wf_market_analyzer.py --help` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_686d2f725bec83289dbd56cf8e352335