### PR TITLE
Add profit vs volume plot output

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Python tool that analyzes the Warframe Market API to find profitable item sets
 
 - Scores items based on a weighted combination of profit, profit margin, and volume
 - Generates a CSV report ordered by score for easy decision-making
+- Saves a scatter plot of profit vs. volume for quick visualization
 
 
 ## Requirements
@@ -30,6 +31,7 @@ A Python tool that analyzes the Warframe Market API to find profitable item sets
    - Install all required packages
    - Run the analyzer
    - Save results to `set_profit_analysis.csv` (or `.xlsx` if configured) in the same folder
+   - Generate `set_profit_analysis_profit_vs_volume.png` for a visual overview
 
 ### Option 2: Manual Setup (All Platforms)
 
@@ -79,6 +81,7 @@ The script will:
 
 4. Generate a score based on profit, profit margin, and volume
 5. Save results to `set_profit_analysis.csv`
+6. Generate `set_profit_analysis_profit_vs_volume.png`
 
 
 ## Configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ aiohttp>=3.8.0
 pandas>=1.3.0
 numpy>=1.20.0
 tqdm>=4.61.0
+matplotlib>=3.0.0

--- a/sample-output.md
+++ b/sample-output.md
@@ -22,5 +22,6 @@ _Note: This is example data and does not reflect actual in-game pricing._
 - **Profit Margin**: Profit divided by total part cost
 - **Score**: Combined normalized score of profit, profit margin, and volume (higher is better)
 - **Part Prices**: Breakdown of each part's price and quantity needed
+- A scatter plot `set_profit_analysis_profit_vs_volume.png` shows profit vs. volume
 
 The results are sorted by Score in descending order, showing the most profitable and frequently traded items at the top.

--- a/wf_market_analyzer.py
+++ b/wf_market_analyzer.py
@@ -8,6 +8,7 @@ import pandas as pd
 import time
 import json
 import logging
+import matplotlib.pyplot as plt
 from typing import Dict, List, Optional
 from dataclasses import dataclass
 from tqdm import tqdm
@@ -174,6 +175,27 @@ class SetProfitAnalyzer:
         self.results = []  # List of ResultData
         self.analyze_trends = analyze_trends
         self.trend_days = trend_days
+
+    def generate_scatter_plot(self) -> None:
+        """Create a scatter plot of profit vs volume and save it as an image"""
+        if not self.results:
+            return
+
+        output_base = OUTPUT_FILE.rsplit('.', 1)[0]
+        plot_file = f"{output_base}_profit_vs_volume.png"
+
+        profits = [r.price_data.profit for r in self.results]
+        volumes = [r.volume_data.volume_48h for r in self.results]
+
+        plt.figure()
+        plt.scatter(volumes, profits)
+        plt.xlabel("Volume (48h)")
+        plt.ylabel("Profit")
+        plt.title("Profit vs. Volume")
+        plt.grid(True)
+        plt.savefig(plot_file)
+        plt.close()
+        logger.info(f"Scatter plot saved to {plot_file}")
 
     async def initialize(self):
         """Initialize the API client"""
@@ -657,6 +679,9 @@ class SetProfitAnalyzer:
             df.to_csv(OUTPUT_FILE, index=False)
         logger.info(f"Results saved to {OUTPUT_FILE}")
 
+        # Generate profit vs. volume scatter plot
+        self.generate_scatter_plot()
+
 
         # Save detailed JSON for debugging
         if DEBUG_MODE:
@@ -731,7 +756,7 @@ async def main(args: argparse.Namespace) -> None:
     try:
         await analyzer.initialize()
         await analyzer.analyze_all_sets()
-        analyzer.save_to_csv()
+        analyzer.save_results()
     except Exception as e:
         logger.error(f"Error in main execution: {str(e)}", exc_info=True)
     finally:


### PR DESCRIPTION
## Summary
- add matplotlib to requirements
- plot profit vs volume after saving results
- fix method call to `save_results`
- document the scatter plot in README and sample output

## Testing
- `python -m py_compile wf_market_analyzer.py`
- `pip install matplotlib`


------
https://chatgpt.com/codex/tasks/task_e_686db753ec64832896e8b169d5437f88