### PR TITLE
Add CLI controls for median pricing and trend analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ python wf_market_analyzer.py --platform xbox --output-file xbox_results.csv \
 
 ```
 
+Additional useful options:
+
+- `--use-median-pricing` to base prices on the median of sampled orders.
+- `--trend-days N` to calculate volume trends over the last `N` days.
+
 The script will:
 1. Fetch all tradable item sets
 2. Calculate profit margins for each set

--- a/config.py
+++ b/config.py
@@ -26,6 +26,9 @@ PROFIT_MARGIN_WEIGHT = 0.0  # Set >0 to factor profit margin into scores
 # Get average/median prices from this many orders
 PRICE_SAMPLE_SIZE = 2
 
+# Use median pricing instead of averaging when calculating prices
+USE_MEDIAN_PRICING = False
+
 codex/implement-lightweight-cache-layer
 # Directory where cached API responses are stored
 CACHE_DIR = 'data'

--- a/wf_market_analyzer.py
+++ b/wf_market_analyzer.py
@@ -5,9 +5,11 @@
 import asyncio
 import aiohttp
 import pandas as pd
+import numpy as np
 import time
 import json
 import logging
+import argparse
 from typing import Dict, List, Optional
 from dataclasses import dataclass
 from tqdm import tqdm
@@ -22,6 +24,7 @@ from config import (
     VOLUME_WEIGHT,
     PROFIT_MARGIN_WEIGHT,
     PRICE_SAMPLE_SIZE,
+    USE_MEDIAN_PRICING,
 )
 
 
@@ -698,6 +701,10 @@ class SetProfitAnalyzer:
 
             logger.info(f"Detailed results saved to {json_file}")
 
+    def save_to_csv(self):
+        """Backward compatibility wrapper."""
+        self.save_results()
+
 
 def parse_arguments() -> argparse.Namespace:
     """Parse command-line arguments"""
@@ -707,13 +714,15 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--profit-weight", type=float, default=PROFIT_WEIGHT, help="Weight for profit in score calculation")
     parser.add_argument("--volume-weight", type=float, default=VOLUME_WEIGHT, help="Weight for 48h volume in score calculation")
     parser.add_argument("--price-sample-size", type=int, default=PRICE_SAMPLE_SIZE, help="Number of orders used when averaging prices")
+    parser.add_argument("--use-median-pricing", action="store_true", default=USE_MEDIAN_PRICING, help="Use median price calculations")
+    parser.add_argument("--trend-days", type=int, help="Calculate volume trend over the last N days")
     parser.add_argument("--debug", action="store_true", default=DEBUG_MODE, help="Enable debug logging")
     return parser.parse_args()
 
 
 async def main(args: argparse.Namespace) -> None:
     """Main entry point"""
-    global OUTPUT_FILE, PROFIT_WEIGHT, VOLUME_WEIGHT, PRICE_SAMPLE_SIZE, DEBUG_MODE
+    global OUTPUT_FILE, PROFIT_WEIGHT, VOLUME_WEIGHT, PRICE_SAMPLE_SIZE, DEBUG_MODE, USE_MEDIAN_PRICING
 
     # Apply command-line overrides
     HEADERS["Platform"] = args.platform
@@ -721,12 +730,16 @@ async def main(args: argparse.Namespace) -> None:
     PROFIT_WEIGHT = args.profit_weight
     VOLUME_WEIGHT = args.volume_weight
     PRICE_SAMPLE_SIZE = args.price_sample_size
+    USE_MEDIAN_PRICING = args.use_median_pricing
     DEBUG_MODE = args.debug
 
     if DEBUG_MODE:
         logger.setLevel(logging.DEBUG)
 
-    analyzer = SetProfitAnalyzer()
+    analyzer = SetProfitAnalyzer(
+        analyze_trends=args.trend_days is not None,
+        trend_days=args.trend_days or 30,
+    )
 
     try:
         await analyzer.initialize()


### PR DESCRIPTION
## Summary
- add `USE_MEDIAN_PRICING` back into `config.py`
- allow `--use-median-pricing` and `--trend-days` via CLI
- wire CLI values into `SetProfitAnalyzer`
- document the new options in the README
- minor wrapper for `save_to_csv`

## Testing
- `python -m py_compile wf_market_analyzer.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db75324a48328b600281a287dda0b