### PR TITLE
Add cache TTL with automatic purging

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Adjust the values in `config.py` to customize how the analyzer behaves:
 - `DEBUG_MODE`: Enable or disable detailed logging
 - `PRICE_SAMPLE_SIZE`: Number of orders to sample when calculating prices
 - `USE_MEDIAN_PRICING`: Use the median price of the sampled orders instead of the average
+- `CACHE_DIR`: Directory where cached API responses are stored
+- `CACHE_TTL_DAYS`: Number of days to keep cache files before they expire. Older files are ignored when loading cached data.
+  Use the `purge_old_cache_files()` helper in `wf_market_analyzer.py` to remove them manually.
 
 ## How Scoring Works
 

--- a/config.py
+++ b/config.py
@@ -1,6 +1,4 @@
-"""
-Configuration settings for Warframe Market Analyzer
-"""
+"""Configuration settings for Warframe Market Analyzer"""
 
 # API Settings
 API_BASE_URL = 'https://api.warframe.market'
@@ -25,8 +23,11 @@ PROFIT_MARGIN_WEIGHT = 0.0  # Set >0 to factor profit margin into scores
 
 # Get average/median prices from this many orders
 PRICE_SAMPLE_SIZE = 2
+# Use median pricing instead of averaging when calculating prices
+USE_MEDIAN_PRICING = False
 
-codex/implement-lightweight-cache-layer
 # Directory where cached API responses are stored
 CACHE_DIR = 'data'
+# Number of days to keep cached API responses
+CACHE_TTL_DAYS = 7
 

--- a/wf_market_analyzer.py
+++ b/wf_market_analyzer.py
@@ -5,9 +5,13 @@
 import asyncio
 import aiohttp
 import pandas as pd
+import numpy as np
 import time
 import json
 import logging
+import os
+import glob
+from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 from dataclasses import dataclass
 from tqdm import tqdm
@@ -22,6 +26,9 @@ from config import (
     VOLUME_WEIGHT,
     PROFIT_MARGIN_WEIGHT,
     PRICE_SAMPLE_SIZE,
+    USE_MEDIAN_PRICING,
+    CACHE_DIR,
+    CACHE_TTL_DAYS,
 )
 
 
@@ -37,6 +44,29 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # Configuration is now loaded from config.py
+
+
+def purge_old_cache_files() -> None:
+    """Delete cache files older than the configured TTL."""
+    if not os.path.isdir(CACHE_DIR):
+        return
+    now = datetime.now()
+    for fname in os.listdir(CACHE_DIR):
+        if not fname.endswith(".json"):
+            continue
+        parts = fname.rsplit('_', 1)
+        if len(parts) < 2:
+            continue
+        date_str = os.path.splitext(parts[1])[0]
+        try:
+            file_date = datetime.strptime(date_str, "%Y-%m-%d")
+        except ValueError:
+            continue
+        if (now - file_date).days > CACHE_TTL_DAYS:
+            try:
+                os.remove(os.path.join(CACHE_DIR, fname))
+            except Exception as e:
+                logger.warning(f"Failed to remove expired cache {fname}: {e}")
 
 
 @dataclass
@@ -169,6 +199,7 @@ class SetProfitAnalyzer:
             analyze_trends: Whether to calculate volume trends
             trend_days: Number of days to use for trend calculations
         """
+        purge_old_cache_files()
         self.api = WarframeMarketAPI()
         self.sets = {}  # slug -> SetData
         self.results = []  # List of ResultData
@@ -191,14 +222,26 @@ class SetProfitAnalyzer:
         return os.path.join(CACHE_DIR, filename)
 
     def _load_cache(self, prefix: str, slug: str) -> Optional[dict]:
-        """Load cached data if available"""
-        path = self._get_cache_path(prefix, slug)
-        if os.path.exists(path):
+        """Load cached data if available and not expired"""
+        pattern = os.path.join(CACHE_DIR, f"{prefix}_{slug}_*.json")
+        newest = None
+        newest_date = None
+        for path in glob.glob(pattern):
+            date_part = os.path.splitext(path)[0].split('_')[-1]
             try:
-                with open(path, 'r') as f:
+                file_date = datetime.strptime(date_part, "%Y-%m-%d")
+            except ValueError:
+                continue
+            if (datetime.now() - file_date).days <= CACHE_TTL_DAYS:
+                if newest_date is None or file_date > newest_date:
+                    newest = path
+                    newest_date = file_date
+        if newest:
+            try:
+                with open(newest, 'r') as f:
                     return json.load(f)
             except Exception as e:
-                logger.warning(f"Failed to load cache {path}: {e}")
+                logger.warning(f"Failed to load cache {newest}: {e}")
         return None
 
     def _save_cache(self, prefix: str, slug: str, data: dict) -> None:


### PR DESCRIPTION
## Summary
- add cache settings to `config.py`
- mention new cache behaviour in README
- track cache TTL when reading cache
- helper added to remove old cache files

## Testing
- `python -m py_compile wf_market_analyzer.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_686db753e8688328b8987318cc59105e