### PR TITLE
Add median pricing config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Adjust the values in `config.py` to customize how the analyzer behaves:
 
 - `DEBUG_MODE`: Enable or disable detailed logging
 - `PRICE_SAMPLE_SIZE`: Number of orders to sample when calculating prices
-- `USE_MEDIAN_PRICING`: Use the median price of the sampled orders instead of the average
+- `USE_MEDIAN_PRICING`: Use the median price of the sampled orders instead of the average (default: False)
 
 ## How Scoring Works
 

--- a/config.py
+++ b/config.py
@@ -25,8 +25,9 @@ PROFIT_MARGIN_WEIGHT = 0.0  # Set >0 to factor profit margin into scores
 
 # Get average/median prices from this many orders
 PRICE_SAMPLE_SIZE = 2
+# Use the median price of the sampled orders instead of the average
+USE_MEDIAN_PRICING = False
 
-codex/implement-lightweight-cache-layer
 # Directory where cached API responses are stored
 CACHE_DIR = 'data'
 


### PR DESCRIPTION
## Summary
- remove stray line in `config.py`
- add `USE_MEDIAN_PRICING` config variable with default `False`
- document default value in README

## Testing
- `python wf_market_analyzer.py --help` *(fails: NameError: name 'argparse' is not defined)*
- `pip install -r requirements.txt` *(no output due to environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686db75226608328a11b2e3b47c65980