### PR TITLE
Fix Warframe Market analyzer URLs and exports

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,7 +1,7 @@
 """Configuration settings for Warframe Market Analyzer"""
 
 # API Settings
-API_BASE_URL = 'https://api.warframe.market'
+API_BASE_URL = 'https://api.warframe.market/v1'
 REQUESTS_PER_SECOND = 2  # Rate limit to avoid API throttling
 HEADERS = {
     'Platform': 'pc',
@@ -13,7 +13,7 @@ HEADERS = {
 # Output Settings
 OUTPUT_FILE = 'set_profit_analysis.csv'
 # Choose 'csv' or 'xlsx'
-OUTPUT_FORMAT = 'csv'
+OUTPUT_FORMAT = 'csv'  # 'csv' or 'xlsx'
 DEBUG_MODE = True  # Enable detailed logging
 
 # Scoring Settings

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy>=1.20.0
 tqdm>=4.61.0
 pytest>=6.0
 matplotlib>=3.0.0
+openpyxl>=3.0.0  # For XLSX output


### PR DESCRIPTION
## Summary
- correct API base URL and update endpoints
- reduce duplicate imports and import argparse & OUTPUT_FORMAT
- parse item sets from v1 API and filter by `_set`
- generate xlsx output when configured
- include openpyxl dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f0f82300832880c3f5788e912b14