### PR TITLE
Fix 24/7 mode scheduling and remove flashing refresh

### DIFF
--- a/wf_market_analyzer.py
+++ b/wf_market_analyzer.py
@@ -539,19 +539,18 @@ class SetProfitAnalyzer:
                 # Get the timestamp of the last entry in the 48h statistics
                 latest_timestamp = stats_48h[-1].get('datetime')
 
-        # Update cache
-        if latest_timestamp:
-            try:
-                conn = sqlite3.connect(DB_PATH)
-                cur = conn.cursor()
-                cur.execute(
-                    "INSERT OR REPLACE INTO volume_cache (item_slug, volume_48h, last_updated) VALUES (?, ?, ?)",
-                    (set_slug, volume_48h, latest_timestamp)
-                )
-                conn.commit()
-                conn.close()
-            except Exception as e:
-                logger.error(f"Failed to write to volume cache: {e}")
+        # Update cache using current timestamp to track when we fetched the data
+        try:
+            conn = sqlite3.connect(DB_PATH)
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT OR REPLACE INTO volume_cache (item_slug, volume_48h, last_updated) VALUES (?, ?, ?)",
+                (set_slug, volume_48h, datetime.now(timezone.utc).isoformat())
+            )
+            conn.commit()
+            conn.close()
+        except Exception as e:
+            logger.error(f"Failed to write to volume cache: {e}")
 
         if DEBUG_MODE:
             logger.debug(f"48-hour volume for {set_slug}: {volume_48h}")


### PR DESCRIPTION
## Summary
- save volume cache with current timestamp so old data warning only appears after an hour
- stabilize 24/7 mode by adding session state tracking and scheduled reruns
- replace constant autorefresh with background thread so UI updates without flashing

## Testing
- `python -m py_compile app.py wf_market_analyzer.py`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a90a20a3083289a7ef52ee2609e03